### PR TITLE
Add locale integration, allow it to be executed in certain environments and return a fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,33 @@
 # GPTFaker
+
 This package adds the possibility to use GPT to generate fake text. It completely integrates with Laravel and their factories.
 
 ## Installation
+
 Install the package using composer:
+
 ```bash
 composer require dejury/gptfaker --dev
 ```
 
 Add this to your `.env` file:
+
 ```php
-OPENAI_API_KEY=<your-api-key>
+FAKERGPT_OPENAI_API_KEY=<your-api-key>
+```
+
+## Config
+
+The config file can be published with the following command:
+
+```
+php artisan vendor:publish --provider="Motivo\GptFaker\GptFakerServiceProvider"
 ```
 
 ## Usage
+
 Use it in your Laravel Factory:
+
 ```php
 <?php
 
@@ -51,10 +65,25 @@ class PageFactory extends Factory
     }
 }
 ```
-### Multilanguage
-Just type the prompt in the language you desire
+
+### Fallback
+
+A fallback can be supplied in case ChatGPT is unable to create a response, the api key is not set or if FakerGPT should not be executed for the given environment.
+By default this value is set to `null` so it is highly recommended to provide a valid fallback.
+
+```php
+$this->faker->gpt(
+    'Create a short paragraph for the page', 
+    $this->faker->paragraph
+),
+```
+
+### Multi-language
+
+Prompts are accepted in every language ChatGPT understands. The results will be translated to your configured faker locale.
 
 ### Multiple prompts
+
 It is possible to give an array with prompts:
 
 ```php
@@ -69,7 +98,12 @@ $choices = $this->faker->unique()->gpt(
 );
 
 return [
-'overview_pretitle' => Str::of($choices[0]?->text)->trim(),
+    'overview_pretitle' => Str::of($choices[0]?->text)->trim(),
 ];
 
 ```
+
+### Environments
+
+You can configure for which environments FakerGPT should be executed. By default this is only for `local` environment.
+This can be changed by publishing the config file as described above and overwriting the `environment` config.

--- a/src/GptFakerServiceProvider.php
+++ b/src/GptFakerServiceProvider.php
@@ -14,10 +14,27 @@ class GptFakerServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/fakergpt.php',
+            'fakergpt',
+        );
+
         $this->app->singleton(Generator::class, function ($app) {
-            $faker = Factory::create($app['config']->get('app.faker_locale', 'en_US'));
-            $faker->addProvider(new GptFaker($faker));
+            $locale = $app['config']->get('app.faker_locale', 'en_US');
+
+            $faker = Factory::create($locale);
+            $faker->addProvider(new GptFaker($faker, $locale));
             return $faker;
         });
+    }
+
+    /**
+     * Bootstrap any package services.
+     */
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__ . '/config/fakergpt.php' => config_path('fakergpt.php'),
+        ]);
     }
 }

--- a/src/config/fakergpt.php
+++ b/src/config/fakergpt.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'openai_api_key' => env('FAKERGPT_OPENAI_API_KEY'),
+
+    'model' => env('FAKERGPT_MODEL', 'text-davinci-003'),
+
+    'max_tokens' => env('FAKERGPT_MAX_TOKENS', 256),
+
+    'temperature' => env('FAKERGPT_TEMPERATURE', 0.7),
+
+    'environments' => [
+        'local',
+    ]
+];


### PR DESCRIPTION
Aangepast:

* Aantal dingen naar config verplaatst
  * env key is nu `FAKERGPT_OPENAI_API_KEY`
  * Config kan worden gepublished
* Locale wordt toegepast
* Je kunt nu opgeven voor welke environments fakergpt uitgevoerd moet worden en voor welke er een fallback gebruikt kan worden