### PR TITLE
Add GptFaker to fake() helper

### DIFF
--- a/src/GptFakerServiceProvider.php
+++ b/src/GptFakerServiceProvider.php
@@ -19,6 +19,10 @@ class GptFakerServiceProvider extends ServiceProvider
             'fakergpt',
         );
 
+        if (function_exists('fake') && class_exists(\Faker\Factory::class)) {
+            fake()->addProvider(new GptFaker(fake(), $this->app->getLocale()));
+        }
+
         $this->app->singleton(Generator::class, function ($app) {
             $locale = $app['config']->get('app.faker_locale', 'en_US');
 


### PR DESCRIPTION
Did not work with the `fake()` helper that is used in factories in later versions of laravel